### PR TITLE
Add PHP 8.2 nginx/mysql docker dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,15 @@ This is a list of all endpoints I've discovered. So far only a subset is impleme
 ## Contributing
 
 If you can improve anything in this repo, feel free to add a pull request or add an issue!
+
+## PHP 8.2 Docker Environment Example
+
+The `php_docker_env` directory contains a simple development setup with PHP 8.2, nginx and MySQL running in two Docker containers. To start the environment, install [Docker](https://www.docker.com/) and run:
+
+```bash
+cd php_docker_env
+docker compose up
+```
+
+Open `http://localhost:8080` in your browser to view the default `phpinfo()` page served by nginx. The MySQL database is exposed on port `3306` with credentials defined in `docker-compose.yml`.
+

--- a/php_docker_env/Dockerfile
+++ b/php_docker_env/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:8.2-fpm
+
+RUN apt-get update \
+    && apt-get install -y nginx \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+COPY index.php /var/www/html/index.php
+
+EXPOSE 80
+CMD ["/entrypoint.sh"]

--- a/php_docker_env/docker-compose.yml
+++ b/php_docker_env/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./index.php:/var/www/html/index.php
+    depends_on:
+      - db
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: app
+      MYSQL_USER: app
+      MYSQL_PASSWORD: app
+    ports:
+      - "3306:3306"

--- a/php_docker_env/entrypoint.sh
+++ b/php_docker_env/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+php-fpm -D
+nginx -g "daemon off;"

--- a/php_docker_env/index.php
+++ b/php_docker_env/index.php
@@ -1,0 +1,3 @@
+<?php
+phpinfo();
+?>

--- a/php_docker_env/nginx.conf
+++ b/php_docker_env/nginx.conf
@@ -1,0 +1,29 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout 65;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        root /var/www/html;
+        index index.php index.html;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        location ~ \.php$ {
+            include fastcgi_params;
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_index index.php;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `php_docker_env` example with Dockerfile, docker-compose and configs
- document how to run the PHP 8.2 nginx+mysql setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a38f1614832d989877968a75fba6